### PR TITLE
Implements num pages #10, fixes bug #13

### DIFF
--- a/SpringCrawler/spiders/url.py
+++ b/SpringCrawler/spiders/url.py
@@ -6,15 +6,22 @@ class URLSpider(scrapy.Spider):
     name = "url"
     start_urls = ['http://quotes.toscrape.com']
 
-    def __init__(self, max_depth=1, *args, **kwargs):
+    def __init__(self, max_depth=1, num_pages=10000, *args, **kwargs):
         super(URLSpider, self).__init__(*args, **kwargs)
         self.max_depth = int(max_depth)
+        self.max_pages = int(num_pages)
+        self.n_pages = 0
+        self.n_seen = 0
 
     def parse(self, response):
 
-        # Exits if the page is empty
-        if response.body == None:
-            return
+        # Tracks the number of URLs the spider has seen
+        self.n_seen += 1
+        self.log(f"Seen {self.n_seen}")
+        
+        # Stop the spider if the maximum pages have been reached
+        if self.n_pages >= self.max_pages:
+            self.crawler.engine.close_spider(self, reason="Page limit reached")
 
         # Get current depth
         depth = response.meta.get('depth', 0)
@@ -24,20 +31,18 @@ class URLSpider(scrapy.Spider):
         os.makedirs(output_dir, exist_ok=True)
 
         # Sets the output filename to be the webpage's title
-        # TODO: Need unique names for webpages due to overwriting for duplicates.
-        # Or need to prune duplicate pages (ie page 1 + page 2)
+        # Probably should make the title unique in some way
         title = response.css('title::text')[0].extract().replace(" ","")
         filename = os.path.join(output_dir, f"{title}.html")
 
         # Write to file
         with open(filename, 'wb') as file:
             file.write(response.body)
-        self.log(f"Saved file {filename} (depth {depth})") # Log to show depth + filename
+        self.log(f"Saved file {filename} (depth {depth}, num {self.n_pages})") # Log to show depth + filename
+        self.n_pages += 1
 
-        # Break if depth is at or past max depth
-        if depth >= self.max_depth:
-            return
-
-        # Otherwise get links and follow them, incrimenting depth
-        for link in response.css('a::attr(href)').getall():
-            yield response.follow(link, callback=self.parse, meta={'depth': depth+1})
+        # Expand if depth limit hasn't been reached
+        if depth < self.max_depth:
+            # Otherwise get links and follow them, incrimenting depth
+            for link in response.css('a::attr(href)').getall():
+                yield response.follow(link, callback=self.parse, meta={'depth': depth+1})


### PR DESCRIPTION
Mainly implements the flag num_pages with a default value of 10000. When the limit is reached or exceeded, the spider stops. There's a log of how many URLs have been seen by the spider just to compare to the number of pages. 

Additionally, fixed the issue of the spider stopping after the depth limit was reached once.